### PR TITLE
Show blur pattern descriptions in usage help

### DIFF
--- a/Sources/FaceMask/Engine/AppEnvironment.swift
+++ b/Sources/FaceMask/Engine/AppEnvironment.swift
@@ -30,12 +30,14 @@ struct AppEnvironment {
 
         self.storageDirectory = storageDirectory
 
-        let allCasesString = BlurPattern.allCases.map { "\($0.rawValue)" }.joined(separator: ", ")
+        let allCasesString = BlurPattern.allCases
+            .map { "\($0.rawValue) - \($0.label): \($0.description)" }
+            .joined(separator: "\n")
         let commandlineArguments = ProcessInfo.processInfo.arguments
         guard commandlineArguments.count >= 2 else {
             CommandLine.error("No arguments provided.")
             CommandLine.warn("Usage: facemask <path_to_video> [<blur_pattern> <circularShape? true/false> <hexColor>]")
-            CommandLine.warn("Valid blur patterns: \(allCasesString)")
+            CommandLine.warn("Valid blur patterns:\n\(allCasesString)")
             exit(1)
         }
 


### PR DESCRIPTION
## Summary
- List each blur pattern's value, name, and description when displaying usage help

## Testing
- `swift test` *(fails: no such module 'AVKit')*

------
https://chatgpt.com/codex/tasks/task_e_6895aeae42a0832bba997bb2d8ecde40